### PR TITLE
Edit画面で投稿したテキストがFirestoreに保存されるようにする

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-core:17.4.1'
     implementation 'com.google.firebase:firebase-auth:19.3.1'
     implementation 'com.google.android.gms:play-services-auth:18.0.0'
+    implementation 'com.google.firebase:firebase-firestore:21.4.3'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/com/example/mydiaryapplication/EditActivity.kt
+++ b/app/src/main/java/com/example/mydiaryapplication/EditActivity.kt
@@ -4,6 +4,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.android.synthetic.main.activity_edit.*
 
@@ -25,7 +26,7 @@ class EditActivity : AppCompatActivity() {
     private fun addNewData() {
 
         val database = FirebaseFirestore.getInstance()
-        //本当はcallendarクラスから日付を取得するが、今は一旦適当な日付を
+
         val date = "2020年5月19日"
         val setDetail = input_edit_detail.text.toString()
 
@@ -34,8 +35,10 @@ class EditActivity : AppCompatActivity() {
             return
         }
 
+        val user = FirebaseAuth.getInstance().currentUser!!.uid
+
         val newData = hashMapOf<String, String>("date" to date, "detail" to setDetail)
-        database.collection("collection").document(date).set(newData)
+        database.collection("users").document(user).collection("notes").add(newData)
             .addOnSuccessListener {
                 Log.d("TAG", "DocumentSnapshot successfully written!")
                 Toast.makeText(this, "登録が完了しました", Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/example/mydiaryapplication/EditActivity.kt
+++ b/app/src/main/java/com/example/mydiaryapplication/EditActivity.kt
@@ -2,6 +2,10 @@ package com.example.mydiaryapplication
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.android.synthetic.main.activity_edit.*
 
 class EditActivity : AppCompatActivity() {
 
@@ -10,7 +14,38 @@ class EditActivity : AppCompatActivity() {
         setContentView(R.layout.activity_edit)
 
         val bundle = intent.extras
-        
+
+        //ボタンはToolbar作成後、修正
+        button_edit_done.setOnClickListener {
+            addNewData()
+        }
+
+    }
+
+    private fun addNewData() {
+
+        val database = FirebaseFirestore.getInstance()
+        //本当はcallendarクラスから日付を取得するが、今は一旦適当な日付を
+        val date = "2020年5月19日"
+        val setDetail = input_edit_detail.text.toString()
+
+        if(setDetail == ""){
+            inputDetail.error = "入力してください"
+            return
+        }
+
+        val newData = hashMapOf<String, String>("date" to date, "detail" to setDetail)
+        database.collection("collection").document(date).set(newData)
+            .addOnSuccessListener {
+                Log.d("TAG", "DocumentSnapshot successfully written!")
+                Toast.makeText(this, "登録が完了しました", Toast.LENGTH_LONG).show()
+                finish()
+
+            }
+            .addOnFailureListener {
+                    e -> Log.w("TAG", "Error writing document", e)
+                Toast.makeText(this, "登録ができませんでした", Toast.LENGTH_LONG).show()
+            }
     }
 
 }

--- a/app/src/main/res/layout/activity_edit.xml
+++ b/app/src/main/res/layout/activity_edit.xml
@@ -25,12 +25,19 @@
             android:layout_height="wrap_content">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_edit_detail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:layout_marginEnd="8dp"
                 android:hint="hint" />
         </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/button_edit_done"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Button" />
 
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
![Annotation 2020-05-19 230732](https://user-images.githubusercontent.com/62502431/82336759-ec785d00-9a25-11ea-9ef2-cd38aa4b65b2.png)
こちらの画像はactivity_edit.xmlのスクリーショットです。(ボタンのデザインは後で変更します。）

![Annotation 2020-05-19 231248](https://user-images.githubusercontent.com/62502431/82337065-4d079a00-9a26-11ea-94a6-599b4893d598.png)
こちらの画像はFirebaseです。保存されました。一度目はdocument名を2020/05/19にしたところ"/"が文字を区切ってしまい3つのdocumentsができたので、2020月05月19日としました。
